### PR TITLE
修复mysql.go的一个小bug

### DIFF
--- a/mysql/mysql.go
+++ b/mysql/mysql.go
@@ -17,6 +17,7 @@ func MysqlAuth(ip string, port string, user string, pass string) ( result bool,e
 	result = false
     db, err := sql.Open("mysql", user+":"+pass+"@tcp("+ip+":"+port+")/mysql?charset=utf8")
     if err != nil {
+	    return result, err
     }
 	if db.Ping()==nil {
 		result = true


### PR DESCRIPTION
不return的话会报db空指针错误